### PR TITLE
Fix wrong cert_path variable name

### DIFF
--- a/ttn/handler.py
+++ b/ttn/handler.py
@@ -24,7 +24,7 @@ class HandlerClient:
         self.app_id = app_id
         self.app_access_key = app_access_key
         if cert_path:
-            cert = read_key(certificate_path)
+            cert = read_key(cert_path)
             self.__open(discovery_address, cert)
         else:
             self.__open(discovery_address)


### PR DESCRIPTION
`certificate_path` is not defined in this scope - `cert_path` should be used.