### PR TITLE
Adding uplink_raw_callback function

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6,6 +6,8 @@
     * [close](#close)
     * [set_uplink_callback](#set_uplink_callback)
         * [uplink_callback](#uplink_callback)
+    * [set_uplink_callback_raw](#set_uplink_callback_raw)
+        * [uplink_callback_raw](#uplink_callback_raw)
     * [set_connect_callback](#set_connect_callback)
         * [connect_callback](#connect_callback)
     * [set_downlink_callback](#set_downlink_callback)
@@ -87,6 +89,23 @@ The callback function must be declared in the script following this structure:
 
 * `uplink_callback(msg, client)`
     * `msg`: **UplinkMessage object** the message received by the client.
+    * `client`: **MQTTClient object** the client from which the callback is executed.
+
+#### set_uplink_callback_raw
+
+Add a callback function, to be called when an uplink message is received.
+This function provides compatibility with existing paho.mqtt.client implementations. 
+
+```python
+client.set_uplink_callback_raw(uplink_callback_raw)
+```
+
+##### uplink_callback_raw
+
+The callback function must be declared in the script following this structure:
+
+* `uplink_callback_raw(msg, client)`
+    * `msg`: **paho.mqtt.client.MQTTMessage object** the message received by the client.
     * `client`: **MQTTClient object** the client from which the callback is executed.
 
 #### set_connect_callback

--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,30 @@ structure:
    -  ``client``: **MQTTClient object** the client from which the
       callback is executed.
 
+set_uplink_callback_raw
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Add a callback function, to be called when an uplink message is
+received. This function provides compatibility with existing
+paho.mqtt.client implementations.
+
+.. code:: python
+
+    client.set_uplink_callback_raw(uplink_callback_raw)
+
+uplink_callback_raw
+'''''''''''''''''''
+
+The callback function must be declared in the script following this
+structure:
+
+-  ``uplink_callback_raw(msg, client)``
+
+   -  ``msg``: **paho.mqtt.client.MQTTMessage object** the message
+      received by the client.
+   -  ``client``: **MQTTClient object** the client from which the
+      callback is executed.
+
 set_connect_callback
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/test_ttnmqtt.py
+++ b/test_ttnmqtt.py
@@ -39,10 +39,16 @@ class TestMQTTClient(unittest.TestCase):
             print(message)
             assert message.payload_raw == "AQ=="
 
+        def uplinkcallback_raw(message, client):
+            print(message)
+            json_message = json.loads(message.payload.decode('utf-8'))
+            assert json_message["payload_raw"] == "AQ=="
+
         ttn_client = mqtt(stubs.apptest["appId"],
                           stubs.apptest["accessKey"],
                           mqtt_address=MQTT_ADDR)
         ttn_client.set_uplink_callback(uplinkcallback)
+        ttn_client.set_uplink_raw_callback(uplinkcallback_raw)
         ttn_client.connect()
         time.sleep(1)
         ttn_client._MQTTClient__client.publish(

--- a/ttn/ttnmqtt.py
+++ b/ttn/ttnmqtt.py
@@ -33,6 +33,7 @@ class DownlinkMessage:
 class MyEvents(Events):
     __events__ = (
         "uplink_msg",
+        "uplink_raw_msg",
         "downlink_msg",
         "connect",
         "close")
@@ -116,6 +117,8 @@ class MQTTClient:
             obj = json2obj(j_msg)
             if self.__events.uplink_msg:
                 self.__events.uplink_msg(obj, client=self)
+            if self.__events.uplink_raw_msg:
+                self.__events.uplink_raw_msg(msg, client=self)
         return on_message
 
     def _on_downlink(self):
@@ -126,6 +129,9 @@ class MQTTClient:
 
     def set_uplink_callback(self, callback):
         self.__events.uplink_msg += callback
+
+    def set_uplink_raw_callback(self, callback):
+        self.__events.uplink_raw_msg += callback
 
     def set_downlink_callback(self, callback):
         self.__events.downlink_msg += callback


### PR DESCRIPTION
uplink_raw_callback function to:
- Maintain compatibility with existing paho.mqtt.client implementations
- Avoid unnecessary conversations to store the messages to nosql databases
  * The existing DownlinkMessage.obj2json() function seems not to work all the time